### PR TITLE
Scroll up / down button feature

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -544,6 +544,6 @@ footer[role="contentinfo"] p {
 .scrollToEndBtn.is-visible {
   display: block;
 }
-.scrollToEnd.up {
+.scrollToEndBtn.up {
   transform: rotate(180deg);
 }

--- a/css/index.css
+++ b/css/index.css
@@ -242,7 +242,7 @@ progress::-webkit-progress-value {
   font-size: 0;
 }
 .reading-time {
-    border: 1px outset var(--blue);
+    border: 1px outset rgba(0,0,51,.1);
     display: inline-block;
     opacity: .8;
     padding: .2em 1em;
@@ -297,6 +297,7 @@ progress::-webkit-progress-value {
   color: transparent;
   text-shadow: 0 0 2px #eaf8ff;
   text-align: center;
+  text-overflow: ellipsis;
 }
 .heading-temporary.slide span {
   top: 0;
@@ -325,6 +326,7 @@ main {
   position: fixed;
   max-width: 25%;
   padding: 20px;
+  background: rgba(255,255,255,.9);
 }
 .parent-nav {
   border-top: 10px solid var(--black);
@@ -515,9 +517,29 @@ aside[role="complementary"] {
 .post-listing-list-item:first-child {
   border-top: 0;
 }
-
 aside[role="complementary"] .byline-component-aside{
   font-size: 1em;
   letter-spacing: 0;
   margin-top: 7px;
+}
+footer[role="contentinfo"] {
+  display: block;
+  text-align: center;
+  padding: 10px 40px;
+  background: var(--light-grey);
+  border-top: 10px solid var(--blue);
+}
+footer[role="contentinfo"] p {
+  font-size: 2em;
+}
+.scrollToEndBtn {
+  position: fixed;
+  z-index: 100;
+  right: 2em;
+  bottom: 2em;
+  cursor: pointer;
+  transition: transform 1s;
+}
+.scrollToEnd.up {
+  transform: rotate(180deg);
 }

--- a/css/index.css
+++ b/css/index.css
@@ -534,11 +534,15 @@ footer[role="contentinfo"] p {
 }
 .scrollToEndBtn {
   position: fixed;
+  display: none;
   z-index: 100;
   right: 2em;
   bottom: 2em;
   cursor: pointer;
   transition: transform 1s;
+}
+.scrollToEndBtn.is-visible {
+  display: block;
 }
 .scrollToEnd.up {
   transform: rotate(180deg);

--- a/index.html
+++ b/index.html
@@ -545,6 +545,11 @@
                 </aside>
 
             </main>
+            
+            <footer role="contentinfo" class="page-footer">                
+                <p class="copyright">&copy; 2020 <span class="author">HUMBER</span></p> 
+                <span class="scrollToEndBtn"><img src="img/btn-arrow.png"></span>
+            </footer>
 
         </div>
 

--- a/js/index.js
+++ b/js/index.js
@@ -385,26 +385,28 @@
                     if (amtScrolled > (1.5 * windowH) && (amtScrolled < (ttlAvailable - windowH))) {
                         // Avoid styling twice
                         !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
-                        //!(btn.classList.contains("up")) ? btn.classList += " up" : btn.classList += '';
+                        (btn.classList.contains("up")) ? btn.classList.remove("up") : btn.classList += '';
                         
-                        // Listen for click to send page down
+                        // 6b. Listen for click to send page down
                         btn.addEventListener('click', () => {
                             scroll('down');
                         });
                                                 
-                    } else if (amtScrolled > (ttlAvailable - windowH) && amtScrolled < (ttlAvailable) ) {    // 6b.
+                    }   // viewport at the very base of document
+                    else if (amtScrolled > (ttlAvailable - windowH) && amtScrolled < (ttlAvailable) ) {    // 6b.
                         // rotate button and prime for scrolling down 
                         !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
-                        //!(btn.classList.contains("up")) ? btn.classList -= " up" : btn.classList -= '';
-                        scroll('up');
+                        !(btn.classList.contains("up")) ? btn.classList += " up" : btn.classList += '';
+                        
+                        // Listen for click to send page up
+                        btn.addEventListener('click', () => {
+                           scroll('up');  
+                        });
+                       
                     }
                     
                     scroll = (dir) => {    // 
-                        if (dir==='up') {
-
-                        } else {
-                             document.documentElement.scrollTop = ttlAvailable; 
-                        }
+                        (dir==='up') ? document.documentElement.scrollTop = 0 : document.documentElement.scrollTop = ttlAvailable; 
                     }
                 
                 });

--- a/js/index.js
+++ b/js/index.js
@@ -55,6 +55,7 @@
 6. SCROLL TO END BUTTON
   6a. Determine when button will be visible. (Now this is by discretion unlike the other methods.
         About one and a half times the height of the viewport from the top of document seems apt)
+  6b. Button should be visible but should scroll down if close to document top.
   
   
 */
@@ -371,14 +372,29 @@
                     
                     let amtScrolled = Math.round(window.scrollY);    // amtScrolled
                     
-                    console.log(amtScrolled);
-                    console.log("windowH ", windowH);
-                
+                    // 6a. (1.5 times the viewport's height from the document top)
                     if (amtScrolled > (1.5 * windowH)) {
-                        alert ('o yea');
+                        let btn = document.querySelector(opts.scrollToEnd.btn);
+                        // Avoid styling twice
+                        !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
+                        //(!btn.classList.contains("is-visible")) ? alert ('yes') : alert ('no');
+                                                
+                    } else {    // 6b.
+                        // rotate button and prime for scrolling down 
+                        !(btn.classList.contains("up")) ? btn.classList += " up" : btn.classList += '';
                     }
                 
                 });
+                
+                // 6b. 
+                
+                scroll (dir) => {    // 
+                    if (dir==='up') {
+                        
+                    } else {
+                        
+                    }
+                }
                 
             }
 

--- a/js/index.js
+++ b/js/index.js
@@ -379,33 +379,38 @@
                     let amtScrolled = Math.round(window.scrollY);    // amtScrolled
                     
                     let btn = document.querySelector(opts.scrollToEnd.btn);
+                    console.log(btn);
                     
                     // 6a. (1.5 times the viewport's height from the document top and not yet at end of document)
                     if (amtScrolled > (1.5 * windowH) && (amtScrolled < (ttlAvailable - windowH))) {
-                        alert ('o yea');
                         // Avoid styling twice
                         !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
-                        !(btn.classList.contains("up")) ? btn.classList -= " up" : btn.classList += '';
+                        //!(btn.classList.contains("up")) ? btn.classList += " up" : btn.classList += '';
+                        
+                        // Listen for click to send page down
+                        btn.addEventListener('click', () => {
+                            scroll('down');
+                        });
                                                 
                     } else if (amtScrolled > (ttlAvailable - windowH) && amtScrolled < (ttlAvailable) ) {    // 6b.
                         // rotate button and prime for scrolling down 
-                        alert ('o no');
                         !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
-                        !(btn.classList.contains("up")) ? btn.classList -= " up" : btn.classList += '';
+                        //!(btn.classList.contains("up")) ? btn.classList -= " up" : btn.classList -= '';
+                        scroll('up');
+                    }
+                    
+                    scroll = (dir) => {    // 
+                        if (dir==='up') {
+
+                        } else {
+                             document.documentElement.scrollTop = ttlAvailable; 
+                        }
                     }
                 
                 });
                 
                 // 6b. 
-                
-                scroll = (dir) => {    // 
-                    if (dir==='up') {
-                        
-                    } else {
-                        
-                    }
-                }
-                
+            
             }
 
         }

--- a/js/index.js
+++ b/js/index.js
@@ -356,6 +356,10 @@
                     
                 });
                 
+            },
+            
+            scrolltoEnd : function () {
+                
             }
 
         }
@@ -388,17 +392,17 @@
     
     let article = doArticle(opts);
 
-   // try {
+   try {
         article.accordion();
         article.progressBar();
         article.scrollspy();
         article.wordcount();
         article.fixedHeading();
- /*   } catch (e) {
+   } catch (e) {
         console.warn("You have some error(s):")
         console.log(e.name);
         console.error(e.name);
-    }*/
+    }
 
 
    

--- a/js/index.js
+++ b/js/index.js
@@ -56,15 +56,13 @@
   6a. Determine when button will be visible. (Now this is by discretion unlike the other methods.
         About one and a half times the height of the viewport from the top of document seems apt)
   6b. Button should be visible but should scroll down if close to document top.
+  6c. Button should scroll up if viewport is at the base of document.
   
   
 */
 
 
     const doArticle = function(opts) {
-
-        const windowH = window.innerHeight;
-
         
         return {
 
@@ -183,7 +181,7 @@
                 
                 let progress = (opts.progressbar.progress);            
                 let $progress = document.querySelector(progress);
-                              
+                                              
                 let windowH = window.innerHeight;   // window Height
                 
                 // 2a. 
@@ -216,6 +214,8 @@
                 //console.log($targets);
                 
                 window.addEventListener('scroll', event =>  {   // listen to scroll on window
+                    
+                    let windowH = window.innerHeight;
                     
                     let $activeLinks = document.querySelectorAll('ul.parent-nav li a.active');
                     const $targets = document.querySelectorAll($text + ', ' + $subtext);
@@ -316,6 +316,8 @@
                                                 
                 window.addEventListener('scroll', event =>  {   // listen to scroll on window
                     
+                    let windowH = window.innerHeight;
+                    
                     let $headings = document.querySelectorAll(`${$text}, ${$subtext}`);
                     
                     for (let i = 0; i < $headings.length; i++) {
@@ -370,25 +372,33 @@
                 
                 window.addEventListener('scroll', event =>  {   // listen to scroll on window
                     
+                    let windowH = window.innerHeight;  
+                    let documentH = document.documentElement.scrollHeight;  // document Height (must always be inside event)
+                    let ttlAvailable = documentH - windowH;  // How much CAN be scrolled
+                    
                     let amtScrolled = Math.round(window.scrollY);    // amtScrolled
                     
-                    // 6a. (1.5 times the viewport's height from the document top)
-                    if (amtScrolled > (1.5 * windowH)) {
-                        let btn = document.querySelector(opts.scrollToEnd.btn);
+                    let btn = document.querySelector(opts.scrollToEnd.btn);
+                    
+                    // 6a. (1.5 times the viewport's height from the document top and not yet at end of document)
+                    if (amtScrolled > (1.5 * windowH) && (amtScrolled < (ttlAvailable - windowH))) {
+                        alert ('o yea');
                         // Avoid styling twice
                         !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
-                        //(!btn.classList.contains("is-visible")) ? alert ('yes') : alert ('no');
+                        !(btn.classList.contains("up")) ? btn.classList -= " up" : btn.classList += '';
                                                 
-                    } else {    // 6b.
+                    } else if (amtScrolled > (ttlAvailable - windowH) && amtScrolled < (ttlAvailable) ) {    // 6b.
                         // rotate button and prime for scrolling down 
-                        !(btn.classList.contains("up")) ? btn.classList += " up" : btn.classList += '';
+                        alert ('o no');
+                        !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
+                        !(btn.classList.contains("up")) ? btn.classList -= " up" : btn.classList += '';
                     }
                 
                 });
                 
                 // 6b. 
                 
-                scroll (dir) => {    // 
+                scroll = (dir) => {    // 
                     if (dir==='up') {
                         
                     } else {

--- a/js/index.js
+++ b/js/index.js
@@ -48,15 +48,22 @@
   4f. Place the values in the document.
   
 5. FIXED HEADING ON SCROLL
-  5a. Check if heading is in view 
-  5b. Reference the heading and showbox and insert heading inside showbox
-  5c. Display new heading when user scrolls into view
+  5a. Check if heading is in view.
+  5b. Reference the heading and showbox and insert heading inside showbox.
+  5c. Display new heading when user scrolls into view.
+  
+6. SCROLL TO END BUTTON
+  6a. Determine when button will be visible. (Now this is by discretion unlike the other methods.
+        About one and a half times the height of the viewport from the top of document seems apt)
+  
+  
 */
 
 
     const doArticle = function(opts) {
 
-        var sec;
+        const windowH = window.innerHeight;
+
         
         return {
 
@@ -204,7 +211,6 @@
                 // 3a.                
                 let $text = (opts.scrollspy.text);
                 let $subtext = (opts.scrollspy.subtext);                
-                let windowH = window.innerHeight;
                 
                 //console.log($targets);
                 
@@ -310,14 +316,13 @@
                 window.addEventListener('scroll', event =>  {   // listen to scroll on window
                     
                     let $headings = document.querySelectorAll(`${$text}, ${$subtext}`);
-                    let amtScrolled = Math.round(window.scrollY);    // amtScrolled
                     
                     for (let i = 0; i < $headings.length; i++) {
                         
                         let $el = ($headings[i]);
                         
                         let id = $el.id;
-                        console.log($el);
+                        //console.log($el);
                                             
                         let hFromTop = Math.round($el.getBoundingClientRect().top);
                         
@@ -360,6 +365,21 @@
             
             scrolltoEnd : function () {
                 
+                let btn = (opts.scrollToEnd.Btn);
+                
+                window.addEventListener('scroll', event =>  {   // listen to scroll on window
+                    
+                    let amtScrolled = Math.round(window.scrollY);    // amtScrolled
+                    
+                    console.log(amtScrolled);
+                    console.log("windowH ", windowH);
+                
+                    if (amtScrolled > (1.5 * windowH)) {
+                        alert ('o yea');
+                    }
+                
+                });
+                
             }
 
         }
@@ -387,18 +407,22 @@
         },
         fixedHeading : {
             header: '.heading-temporary > span:first-of-type'            
+        },
+        scrollToEnd : {
+            btn: '.scrollToEndBtn'
         }
     }
     
     let article = doArticle(opts);
 
-   try {
+    try {
         article.accordion();
         article.progressBar();
         article.scrollspy();
         article.wordcount();
         article.fixedHeading();
-   } catch (e) {
+        article.scrolltoEnd();
+    } catch (e) {
         console.warn("You have some error(s):")
         console.log(e.name);
         console.error(e.name);


### PR DESCRIPTION
# Related Issue

Fixes #19 

# Proposed Change

Used the same button to implement duo-functionality of page scroll. This ensures user can easily get to top or bottom of page without having to painlessly scroll for longer durations.

# Main code responsible for this feature as raised in #19 is as follows: 
`                    // 6a. (1.5 times the viewport's height from the document top and not yet at end of document)
                    if (amtScrolled > (1.5 * windowH) && (amtScrolled < (ttlAvailable - windowH))) {
                        // Avoid styling twice
                        !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
                        (btn.classList.contains("up")) ? btn.classList.remove("up") : btn.classList += '';
                        // 6b. Listen for click to send page down
                        btn.addEventListener('click', () => {
                            scroll('down');
                        });
                    }   // viewport at the very base of document
                    else if (amtScrolled > (ttlAvailable - windowH) && amtScrolled < (ttlAvailable) ) {    // 6b.
                        // rotate button and prime for scrolling down 
                        !(btn.classList.contains("is-visible")) ? btn.classList += " is-visible" : btn.classList += '';
                        !(btn.classList.contains("up")) ? btn.classList += " up" : btn.classList += '';
                        // Listen for click to send page up
                        btn.addEventListener('click', () => {
                           scroll('up');  
                        });
                    }
                    scroll = (dir) => {    // 
                        (dir==='up') ? document.documentElement.scrollTop = 0 : document.documentElement.scrollTop = ttlAvailable; 
                    }`